### PR TITLE
Fix SessionHelper#isSelect

### DIFF
--- a/src/net/sf/persism/SessionHelper.java
+++ b/src/net/sf/persism/SessionHelper.java
@@ -620,7 +620,7 @@ final class SessionHelper {
             for (Object child : childList) {
                 Object parent = parentMap.get(childPropertyInfo.getValue(child));
                 if (parent == null) {
-                    // todo this could occur many to 1 where the 1 is not a required valueA clear and concise description of what the bug is.
+                    // todo this could occur many to 1 where the 1 is not a required value
                     log.warnNoDuplicates("parent not found: " + childPropertyInfo.getValue(child) + " : " + joinInfo + "DAO: " + child); // Should not usually occur. Why would we not find a parent?
                 } else {
                     setPropertyFromJoinInfo(joinInfo, parent, child);

--- a/src/net/sf/persism/SessionHelper.java
+++ b/src/net/sf/persism/SessionHelper.java
@@ -620,7 +620,7 @@ final class SessionHelper {
             for (Object child : childList) {
                 Object parent = parentMap.get(childPropertyInfo.getValue(child));
                 if (parent == null) {
-                    // todo this could occur many to 1 where the 1 is not a required value
+                    // todo this could occur many to 1 where the 1 is not a required valueA clear and concise description of what the bug is.
                     log.warnNoDuplicates("parent not found: " + childPropertyInfo.getValue(child) + " : " + joinInfo + "DAO: " + child); // Should not usually occur. Why would we not find a parent?
                 } else {
                     setPropertyFromJoinInfo(joinInfo, parent, child);
@@ -775,7 +775,7 @@ final class SessionHelper {
 
     boolean isSelect(String sql) {
         assert sql != null;
-        return sql.trim().substring(0, 7).equalsIgnoreCase("select ");
+        return sql.trim().substring(0, 6).equalsIgnoreCase("select");
     }
 
     <T> void checkIfStoredProcOrSQL(Class<T> objectClass, SQL sql) {


### PR DESCRIPTION
Some databases like PostgreSQL support using `SELECT` clause followed by any whitespaces including '\n', '\t' and ' ', which is quiet common in multiline sql codes.